### PR TITLE
[ECS] Fix config example showing usage of CACHE_DIRECTORY option as array

### DIFF
--- a/packages/easy-coding-standard/README.md
+++ b/packages/easy-coding-standard/README.md
@@ -299,7 +299,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     // default: sys_get_temp_dir() . '/_changed_files_detector_tests'
-    $parameters->set(Option::CACHE_DIRECTORY, ['.ecs_cache']);
+    $parameters->set(Option::CACHE_DIRECTORY, '.ecs_cache');
 
     // default: Strings::webalize(getcwd())'
     $parameters->set(Option::CACHE_NAMESPACE, 'my_project_namespace');


### PR DESCRIPTION
Accordingly to [phpdoc](https://github.com/symplify/symplify/blob/master/packages/easy-coding-standard/packages/configuration/src/Option.php#L73), `CACHE_DIRECTORY` option must be a string.

See also #2087. 