### PR TITLE
Added support for Nette\Application\UI\ITemplate

### DIFF
--- a/packages/astral/src/NodeAnalyzer/NetteTypeAnalyzer.php
+++ b/packages/astral/src/NodeAnalyzer/NetteTypeAnalyzer.php
@@ -18,6 +18,7 @@ final class NetteTypeAnalyzer
      */
     private const TEMPLATE_TYPES = [
         'Nette\Application\UI\Template',
+        'Nette\Application\UI\ITemplate',
         'Nette\Bridges\ApplicationLatte\Template',
         'Nette\Bridges\ApplicationLatte\DefaultTemplate',
     ];


### PR DESCRIPTION
In my 2.4 - 3.0 Nette applications there is Nette\Application\UI\ITemplate type for $this->template