### PR TITLE
[ECS] Bugfix | Prevent fatal error when running parallel with problem

### DIFF
--- a/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symplify\EasyCodingStandard\Parallel\Command\WorkerCommandLineFactory;
 use Symplify\EasyCodingStandard\Parallel\Enum\Action;
 use Symplify\EasyCodingStandard\Parallel\ValueObject\Bridge;
+use Symplify\EasyCodingStandard\Parallel\ValueObject\Name;
 use Symplify\EasyCodingStandard\Parallel\ValueObject\ParallelProcess;
 use Symplify\EasyCodingStandard\Parallel\ValueObject\ProcessPool;
 use Symplify\EasyCodingStandard\Parallel\ValueObject\ReactCommand;
@@ -117,8 +118,7 @@ final class ParallelFileProcessor
 
         $reachedSystemErrorsCountLimit = false;
 
-        $handleErrorCallable = static function (Throwable $throwable) use (
-            $streamSelectLoop,
+        $handleErrorCallable = function (Throwable $throwable) use (
             &$systemErrors,
             &$systemErrorsCount,
             &$reachedSystemErrorsCountLimit
@@ -165,6 +165,10 @@ final class ParallelFileProcessor
                     foreach ($json[Bridge::SYSTEM_ERRORS] as $jsonError) {
                         if (is_string($jsonError)) {
                             $systemErrors[] = sprintf('System error: %s', $jsonError);
+                            continue;
+                        }
+                        if (!isset($jsonError[Name::CHECKER_CLASS])) {
+                            $systemErrors[] = $jsonError[Name::MESSAGE];
                             continue;
                         }
 


### PR DESCRIPTION
Related to #3650 (note that this change is **not** fixing the issue itself).

With this simple check my parallel run on the sample project from issue (https://github.com/AlbertoBarba/ecs-sample) was able to finish with errors but without fatal.

If in run error didn't occur it was clear:
```
 [OK] 398 errors successfully fixed and no other errors found!   
```
If there was problem in running:
```
> vendor/bin/ecs check --fix

 [ERROR] Unable to write in the "cache" directory                               
         (/var/folders/8s/7mkw91gd1gs3chv4xhmcv6vr0000gn/T/ecs_jozefbielawski). 

   0/400 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 400/400 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%Script vendor/bin/ecs check --fix handling the ecs event returned with error code 1
```
It was at least able to proceed.