### PR TITLE
[ECS] Remove `static` from function in `ParallelFileProcessor` as it uses class methods

### DIFF
--- a/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
@@ -117,7 +117,7 @@ final class ParallelFileProcessor
 
         $reachedSystemErrorsCountLimit = false;
 
-        $handleErrorCallable = static function (Throwable $throwable) use (
+        $handleErrorCallable = function (Throwable $throwable) use (
             $streamSelectLoop,
             &$systemErrors,
             &$systemErrorsCount,


### PR DESCRIPTION
This cannot be static as inside there is call to $this (line 130):
```php
$this->processPool->quitAll();
```