### PR TITLE
fix vendor folder with "." in name

### DIFF
--- a/packages/vendor-patches/src/Differ/PatchDiffer.php
+++ b/packages/vendor-patches/src/Differ/PatchDiffer.php
@@ -16,7 +16,7 @@ use Symplify\VendorPatches\ValueObject\OldAndNewFileInfo;
 final class PatchDiffer
 {
     /**
-     * @see https://regex101.com/r/0O5NO1/3
+     * @see https://regex101.com/r/0O5NO1/4
      * @var string
      */
     private const LOCAL_PATH_REGEX = '#vendor\/[^\/]+\/[^\/]+\/(?<local_path>.*?)$#is';


### PR DESCRIPTION
Unfortunately we have a vendor folder called `vendor/store.shopware.com/plugin` which doesn't match the given regex.