### PR TITLE
[PHPStanTwig/LatteRules] Improve template and line

### DIFF
--- a/packages/phpstan-latte-rules/src/Rules/LatteCompleteCheckRule.php
+++ b/packages/phpstan-latte-rules/src/Rules/LatteCompleteCheckRule.php
@@ -99,7 +99,8 @@ final class LatteCompleteCheckRule extends AbstractSymplifyRule
                 $resolvedTemplateFilePath,
                 $renderTemplateWithParameters->getParametersArray(),
                 $scope,
-                $componentNamesAndTypes
+                $componentNamesAndTypes,
+                $node->getLine()
             );
 
             $errors = array_merge($errors, $currentErrors);
@@ -158,7 +159,8 @@ CODE_SAMPLE
         string $templateFilePath,
         Array_ $array,
         Scope $scope,
-        array $componentNamesAndTypes
+        array $componentNamesAndTypes,
+        int $phpLine
     ): array {
         try {
             $phpFileContentsWithLineMap = $this->templateFileVarTypeDocBlocksDecorator->decorate(
@@ -185,6 +187,12 @@ CODE_SAMPLE
         // remove errors related to just created class, that cannot be autoloaded
         $errors = $this->errorSkipper->skipErrors($fileAnalyserResult->getErrors(), self::USELESS_ERRORS_IGNORES);
 
-        return $this->templateErrorsFactory->createErrors($errors, $templateFilePath, $phpFileContentsWithLineMap);
+        return $this->templateErrorsFactory->createErrors(
+            $errors,
+            $scope->getFile(),
+            $templateFilePath,
+            $phpFileContentsWithLineMap,
+            $phpLine
+        );
     }
 }

--- a/packages/phpstan-latte-rules/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
+++ b/packages/phpstan-latte-rules/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
@@ -30,42 +30,31 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
     {
         // tests @see \PHPStan\Rules\Methods\CallMethodsRule
         $errorMessage = sprintf('Call to an undefined method %s::missingMethod().', SomeTypeWithMethods::class);
-        yield [__DIR__ . '/Fixture/SomeMissingMethodCall.php', [[$errorMessage, 1]]];
+        yield [__DIR__ . '/Fixture/SomeMissingMethodCall.php', [[$errorMessage, 16]]];
 
         // tests @see \PHPStan\Rules\Methods\CallMethodsRule
         $errorMessage = sprintf(
             'Parameter #1 $name of method %s::render() expects string, int given.',
             InvalidControlRenderArguments::class
         );
-        yield [__DIR__ . '/Fixture/InvalidControlRenderArguments.php', [[$errorMessage, 1]]];
+        yield [__DIR__ . '/Fixture/InvalidControlRenderArguments.php', [[$errorMessage, 17]]];
 
         yield [__DIR__ . '/Fixture/SkipExistingMethodCall.php', []];
         yield [__DIR__ . '/Fixture/SkipVariableInBlockControl.php', []];
 
-        $errorMessages = [
-            ['Variable $nonExistingVariable might not be defined.', 3],
-            ['Call to an undefined method Nette\Security\User::nonExistingMethod().', 6],
-            [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), 9],
-            [
-                'Method ' . InvalidControlRenderArguments::class . '::render() invoked with 2 parameters, 1 required.',
-                12,
-            ],
-            [
-                'Parameter #1 $name of method ' . InvalidControlRenderArguments::class . '::render() expects string, int given.',
-                12,
-            ],
+        yield [__DIR__ . '/Fixture/GetTemplateAndReplaceExtension.php', $this->createSharedErrorMessages(20)];
+        yield [__DIR__ . '/Fixture/NoAdditionalPropertyRead.php', $this->createSharedErrorMessages(20)];
+        yield [__DIR__ . '/Fixture/PropertyReadTemplate.php', $this->createSharedErrorMessages(24)];
+        yield [__DIR__ . '/Fixture/RenderWithParameters.php', $this->createSharedErrorMessages(17)];
+        yield [
+            __DIR__ . '/Fixture/TemplateAsVariableAndRenderToStringWithParameters.php',
+            $this->createSharedErrorMessages(20),
         ];
 
-        yield [__DIR__ . '/Fixture/GetTemplateAndReplaceExtension.php', $errorMessages];
-        yield [__DIR__ . '/Fixture/NoAdditionalPropertyRead.php', $errorMessages];
-        yield [__DIR__ . '/Fixture/PropertyReadTemplate.php', $errorMessages];
-        yield [__DIR__ . '/Fixture/RenderWithParameters.php', $errorMessages];
-        yield [__DIR__ . '/Fixture/TemplateAsVariableAndRenderToStringWithParameters.php', $errorMessages];
-
         $errorMessages = [
-            ['Variable $nonExistingVariable might not be defined.', 3],
-            ['Call to an undefined method Nette\Security\User::nonExistingMethod().', 6],
-            [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), 9],
+            ['Variable $nonExistingVariable might not be defined.', 21],
+            ['Call to an undefined method Nette\Security\User::nonExistingMethod().', 21],
+            [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), 21],
         ];
         yield [__DIR__ . '/Fixture/ControlWithForm.php', $errorMessages];
     }
@@ -73,5 +62,25 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
     protected function getRule(): Rule
     {
         return $this->getRuleFromConfig(LatteCompleteCheckRule::class, __DIR__ . '/config/configured_rule.neon');
+    }
+
+    /**
+     * @return array<array<string|int>>
+     */
+    private function createSharedErrorMessages(int $phpLine): array
+    {
+        return [
+            ['Variable $nonExistingVariable might not be defined.', $phpLine],
+            ['Call to an undefined method Nette\Security\User::nonExistingMethod().', $phpLine],
+            [sprintf('Call to an undefined method %s::getTitle().', ExampleModel::class), $phpLine],
+            [
+                'Method ' . InvalidControlRenderArguments::class . '::render() invoked with 2 parameters, 1 required.',
+                $phpLine,
+            ],
+            [
+                'Parameter #1 $name of method ' . InvalidControlRenderArguments::class . '::render() expects string, int given.',
+                $phpLine,
+            ],
+        ];
     }
 }

--- a/packages/phpstan-twig-rules/tests/Rules/TwigCompleteCheckRule/TwigCompleteCheckRuleTest.php
+++ b/packages/phpstan-twig-rules/tests/Rules/TwigCompleteCheckRule/TwigCompleteCheckRuleTest.php
@@ -27,13 +27,13 @@ final class TwigCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
     public function provideData(): Iterator
     {
         $errorMessage = sprintf('Call to an undefined method %s::nonExistingMethod().', SomeType::class);
-        yield [__DIR__ . '/Fixture/SomeMissingVariableController.php', [[$errorMessage, 1]]];
+        yield [__DIR__ . '/Fixture/SomeMissingVariableController.php', [[$errorMessage, 17]]];
 
         $firstErrorMessage = sprintf('Call to an undefined method %s::nonExistingMethod().', SomeType::class);
-        yield [__DIR__ . '/Fixture/FirstForeachMissing.php', [[$firstErrorMessage, 2]]];
+        yield [__DIR__ . '/Fixture/FirstForeachMissing.php', [[$firstErrorMessage, 20]]];
 
         $secondErrorMessage = sprintf('Call to an undefined method %s::blabla().', SomeType::class);
-        yield [__DIR__ . '/Fixture/SomeForeachMissingVariableController.php', [[$secondErrorMessage, 5]]];
+        yield [__DIR__ . '/Fixture/SomeForeachMissingVariableController.php', [[$secondErrorMessage, 20]]];
 
         yield [__DIR__ . '/Fixture/SkipExistingMethod.php', []];
         yield [__DIR__ . '/Fixture/SkipExistingProperty.php', []];


### PR DESCRIPTION
Ref https://twitter.com/VotrubaT/status/1451186101108887558

## Changes

- this also fixes invalidated cache bug, when template didn't invoke override of result cache

## How does it Look?

`--error-format symplify` is needed, as PHPStan can show only single file path

![Peek 2021-10-21 15-57](https://user-images.githubusercontent.com/924196/138338424-f3439514-e87e-4da5-a072-805bb5f24ee1.gif)

