### PR TITLE
ECS: Add more details in case of failure

### DIFF
--- a/packages/easy-coding-standard/bin/ecs.php
+++ b/packages/easy-coding-standard/bin/ecs.php
@@ -38,6 +38,7 @@ try {
     $symfonyStyleFactory = new SymfonyStyleFactory();
     $symfonyStyle = $symfonyStyleFactory->create();
     $symfonyStyle->error($throwable->getMessage());
+    $symfonyStyle->writeln($throwable->getTraceAsString());
     exit(Command::FAILURE);
 }
 


### PR DESCRIPTION
I had an issue and the stacktrace was missing: impossible to debug without it.

Btw guys this package do not have any dependency but does not work without many deps. This is weird. I think it's actually not usable as a standalone package...