### PR TITLE
[ECS] Deprecate outdated php-cs-fixer native sets as barely used

### DIFF
--- a/packages/easy-coding-standard/config/set/php-cs-fixer-risky.php
+++ b/packages/easy-coding-standard/config/set/php-cs-fixer-risky.php
@@ -33,6 +33,18 @@ use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\StringLineEndingFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
+
+$deprecatedMessage = sprintf(
+    'The "%s" set from ECS is outdated and deprecated. Use "%s" with custom loader to use the latest configuration always updated, or even better switch to more standard PSR 12.',
+    'SetList::PHP_CS_FIXER_RISKY',
+    'https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/PhpCsFixerRiskySet.php'
+);
+
+$symfonyStyleFactory = new SymfonyStyleFactory();
+$symfonyStyle = $symfonyStyleFactory->create();
+$symfonyStyle->warning($deprecatedMessage);
+sleep(3);
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->rules([

--- a/packages/easy-coding-standard/config/set/php-cs-fixer.php
+++ b/packages/easy-coding-standard/config/set/php-cs-fixer.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
+
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer;
@@ -136,6 +137,18 @@ use PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
+
+$deprecatedMessage = sprintf(
+    'The "%s" set from ECS is outdated and deprecated. Use "%s" with custom loader to use the latest configuration always updated, or even better switch to more standard PSR 12.',
+    'SetList::PHP_CS_FIXER',
+    'https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/PhpCsFixerSet.php'
+);
+
+$symfonyStyleFactory = new SymfonyStyleFactory();
+$symfonyStyle = $symfonyStyleFactory->create();
+$symfonyStyle->warning($deprecatedMessage);
+sleep(3);
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [

--- a/packages/easy-coding-standard/config/set/symfony-risky.php
+++ b/packages/easy-coding-standard/config/set/symfony-risky.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Alias\EregToPregFixer;
+
 use PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer;
 use PhpCsFixer\Fixer\Alias\SetTypeToCastFixer;
 use PhpCsFixer\Fixer\Basic\NonPrintableCharacterFixer;
@@ -22,6 +23,19 @@ use PhpCsFixer\Fixer\Naming\NoHomoglyphNamesFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitConstructFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMockShortWillReturnFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
+
+$deprecatedMessage = sprintf(
+    'The "%s" set from ECS is outdated and deprecated. Use "%s" with custom loader to use the latest configuration always updated, or even better switch to more standard PSR 12.',
+    'SetList::SYMFONY_RISKY',
+    'https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/SymfonySet.php'
+);
+
+$symfonyStyleFactory = new SymfonyStyleFactory();
+$symfonyStyle = $symfonyStyleFactory->create();
+$symfonyStyle->warning($deprecatedMessage);
+sleep(3);
+
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(FopenFlagsFixer::class, [

--- a/packages/easy-coding-standard/config/set/symfony.php
+++ b/packages/easy-coding-standard/config/set/symfony.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
+
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer;
@@ -106,6 +107,18 @@ use PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
+
+$deprecatedMessage = sprintf(
+    'The "%s" set from ECS is outdated and deprecated. Use "%s" with custom loader to use the latest configuration always updated, or even better switch to more standard PSR 12.',
+    'SetList::SYMFONY',
+    'https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/SymfonyRiskySet.php'
+);
+
+$symfonyStyleFactory = new SymfonyStyleFactory();
+$symfonyStyle = $symfonyStyleFactory->create();
+$symfonyStyle->warning($deprecatedMessage);
+sleep(3);
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [

--- a/packages/easy-coding-standard/src/ValueObject/Set/SetList.php
+++ b/packages/easy-coding-standard/src/ValueObject/Set/SetList.php
@@ -13,12 +13,14 @@ final class SetList
     public const PSR_12 = __DIR__ . '/../../../config/set/psr12.php';
 
     /**
+     * @deprecated This set is outdated and will be removed in the future. Use PSR-12 or directly https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master/src/RuleSet/Sets
      * @var string
      * @api
      */
     public const PHP_CS_FIXER = __DIR__ . '/../../../config/set/php-cs-fixer.php';
 
     /**
+     * @deprecated This set is outdated and will be removed in the future. Use PSR-12 or directly https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master/src/RuleSet/Sets
      * @var string
      * @api
      */
@@ -91,12 +93,14 @@ final class SetList
     public const STRICT = __DIR__ . '/../../../config/set/common/strict.php';
 
     /**
+     * @deprecated This set is outdated and will be removed in the future. Use PSR-12 or directly https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master/src/RuleSet/Sets
      * @var string
      * @api
      */
     public const SYMFONY = __DIR__ . '/../../../config/set/symfony.php';
 
     /**
+     * @deprecated This set is outdated and will be removed in the future. Use PSR-12 or directly https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master/src/RuleSet/Sets
      * @var string
      * @api
      */


### PR DESCRIPTION
These 4 sets were copied many years ago from php-cs-fixer. They're not maintained and updated, as they don't bring any extra value. 

You can use directly the test from php-cs-fixer: https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/master/src/RuleSet/Sets,
or even better, **go for PSR-12** that handles the code in pretty detailed and standard way :+1: 
